### PR TITLE
Implemented job activation per lifetime scope

### DIFF
--- a/HangFire.Autofac/AutofacContainerPerJobFilterAttribute.cs
+++ b/HangFire.Autofac/AutofacContainerPerJobFilterAttribute.cs
@@ -1,0 +1,25 @@
+﻿using Hangfire.Common;
+using Hangfire.Server;
+
+namespace Hangfire
+{
+    public class AutofacContainerPerJobFilterAttribute : JobFilterAttribute, IServerFilter
+    {
+        private readonly AutofacPerLifetimeScopeJobActivator _autofacPerLifetimeScopeJobActivator;
+
+        public AutofacContainerPerJobFilterAttribute(AutofacPerLifetimeScopeJobActivator autofacPerLifetimeScopeJobActivator)
+        {
+            _autofacPerLifetimeScopeJobActivator = autofacPerLifetimeScopeJobActivator;
+        }
+
+        public void OnPerformed(PerformedContext filterContext)
+        {
+            _autofacPerLifetimeScopeJobActivator.DisposeJobLifetimeScope();
+        }
+
+        public void OnPerforming(PerformingContext filterContext)
+        {
+            _autofacPerLifetimeScopeJobActivator.CreateJobLifetimeScope();
+        }
+    }
+}

--- a/HangFire.Autofac/AutofacPerLifetimeScopeJobActivator.cs
+++ b/HangFire.Autofac/AutofacPerLifetimeScopeJobActivator.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Autofac;
+
+namespace Hangfire
+{
+    public class AutofacPerLifetimeScopeJobActivator : JobActivator
+    {
+          private static IContainer _mainContainer;
+
+        [ThreadStatic]
+        private static ILifetimeScope _childLifetimeScope;
+
+        public AutofacPerLifetimeScopeJobActivator(IContainer container)
+        {
+            _mainContainer = container;
+        }
+
+        public override object ActivateJob(Type jobType)
+        {
+            return _childLifetimeScope.Resolve(jobType);
+        }
+
+        public void CreateJobLifetimeScope()
+        {
+            _childLifetimeScope = _mainContainer.BeginLifetimeScope();
+        }
+
+        public void DisposeJobLifetimeScope()
+        {
+            _childLifetimeScope.Dispose();
+            _childLifetimeScope = null;
+        }
+    }
+}

--- a/HangFire.Autofac/HangFire.Autofac.csproj
+++ b/HangFire.Autofac/HangFire.Autofac.csproj
@@ -63,8 +63,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutofacBootstrapperConfigurationExtensions.cs" />
+    <Compile Include="AutofacContainerPerJobFilterAttribute.cs" />
     <Compile Include="AutofacJobActivator.cs" />
+    <Compile Include="AutofacPerLifetimeScopeJobActivator.cs" />
     <Compile Include="GlobalConfigurationExtensions.cs" />
+    <Compile Include="HangfirePerLifetimeScopeConfigurer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/HangFire.Autofac/HangfirePerLifetimeScopeConfigurer.cs
+++ b/HangFire.Autofac/HangfirePerLifetimeScopeConfigurer.cs
@@ -1,0 +1,14 @@
+﻿using Autofac;
+
+namespace Hangfire
+{
+    public static class HangfirePerLifetimeScopeConfigurer
+    {
+        public static void Configure(IContainer container)
+        {
+            var autofacPerLifetimeScopeJobActivator = new AutofacPerLifetimeScopeJobActivator(container);
+            JobActivator.Current = autofacPerLifetimeScopeJobActivator;
+            GlobalJobFilters.Filters.Add(new AutofacContainerPerJobFilterAttribute(autofacPerLifetimeScopeJobActivator));
+        }
+    }
+}


### PR DESCRIPTION
Hangfire does not support per lifetime scope containers. This means that all
dependencies will be shared between jobs, which is far from ideal,
especially when you have IDbContext. This is on the road map of Hangfire 2.0.
We need a work around this. This is why we add our own
AutofacJobActivator and a JobFilter to manage a per job lifetime scope.