### PR TITLE
Added useTaggedLifetimeScope for AutofacJobActivator

### DIFF
--- a/HangFire.Autofac/AutofacBootstrapperConfigurationExtensions.cs
+++ b/HangFire.Autofac/AutofacBootstrapperConfigurationExtensions.cs
@@ -11,12 +11,13 @@ namespace Hangfire
         /// </summary>
         /// <param name="configuration">Configuration</param>
         /// <param name="lifetimeScope">Autofac lifetime scope that will be used to activate jobs</param>
+        /// <param name="useTaggedLifetimeScope">should tagged lifetimeScopes be used</param>
         [Obsolete("Please use `GlobalConfiguration.Configuration.UseAutofacActivator` method instead. Will be removed in version 2.0.0.")]
         public static void UseAutofacActivator(
             this IBootstrapperConfiguration configuration,
-            ILifetimeScope lifetimeScope)
+            ILifetimeScope lifetimeScope, bool useTaggedLifetimeScope = true)
         {
-            configuration.UseActivator(new AutofacJobActivator(lifetimeScope));
+            configuration.UseActivator(new AutofacJobActivator(lifetimeScope, useTaggedLifetimeScope));
         }
     }
 }

--- a/HangFire.Autofac/AutofacJobActivator.cs
+++ b/HangFire.Autofac/AutofacJobActivator.cs
@@ -15,6 +15,7 @@ namespace Hangfire
         public static readonly object LifetimeScopeTag = "BackgroundJobScope";
 
         private readonly ILifetimeScope _lifetimeScope;
+        private readonly bool _useTaggedLifetimeScope;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AutofacJobActivator"/>
@@ -22,10 +23,13 @@ namespace Hangfire
         /// </summary>
         /// <param name="lifetimeScope">Container that will be used to create instance
         /// of classes during job activation process.</param>
-        public AutofacJobActivator([NotNull] ILifetimeScope lifetimeScope)
+        /// <param name="useTaggedLifetimeScope">Should the Container use Tag 
+        /// BackgroundJobScope to resolve dependencies or create new Scope on each job</param>
+        public AutofacJobActivator([NotNull] ILifetimeScope lifetimeScope, bool useTaggedLifetimeScope = true)
         {
             if (lifetimeScope == null) throw new ArgumentNullException("lifetimeScope");
             _lifetimeScope = lifetimeScope;
+            _useTaggedLifetimeScope = useTaggedLifetimeScope;
         }
 
         /// <inheritdoc />
@@ -36,7 +40,9 @@ namespace Hangfire
 
         public override JobActivatorScope BeginScope()
         {
-            return new AutofacScope(_lifetimeScope.BeginLifetimeScope(LifetimeScopeTag));
+            return new AutofacScope(_useTaggedLifetimeScope
+                ? _lifetimeScope.BeginLifetimeScope(LifetimeScopeTag)
+                : _lifetimeScope.BeginLifetimeScope());
         }
 
         class AutofacScope : JobActivatorScope

--- a/HangFire.Autofac/GlobalConfigurationExtensions.cs
+++ b/HangFire.Autofac/GlobalConfigurationExtensions.cs
@@ -8,12 +8,12 @@ namespace Hangfire
     {
         public static IGlobalConfiguration<AutofacJobActivator> UseAutofacActivator(
             [NotNull] this IGlobalConfiguration configuration, 
-            [NotNull] ILifetimeScope lifetimeScope)
+            [NotNull] ILifetimeScope lifetimeScope, bool useTaggedLifetimeScope = true)
         {
             if (configuration == null) throw new ArgumentNullException("configuration");
             if (lifetimeScope == null) throw new ArgumentNullException("lifetimeScope");
 
-            return configuration.UseActivator(new AutofacJobActivator(lifetimeScope));
+            return configuration.UseActivator(new AutofacJobActivator(lifetimeScope, useTaggedLifetimeScope));
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ Sometimes it is required to share the same service instance for different compon
 builder.RegisterType<Database>().InstancePerBackgroundJob();
 ```
 
+### Non-tagged scopes
+
+Whenever the scopes in `AutofacActivator` are created, by default they are created using tag `BackgroundJobScope`. There might be a scenario when it is needed not to use tagged scopes though. This might be a case if it is required to have a new instance of every service for each lifetime scope (in Hangfire it would be for every job). To disable tagged scopes you can use a flag `useTaggedLifetimeScope` during initialization of `AutofacActivator` for Hangfire.
+
+```csharp
+var builder = new ContainerBuilder();
+// builder.Register...
+
+GlobalConfiguration.Configuration.UseAutofacActivator(builder.Build(), false);
+```
+
+Then you can register services by using `InstancePerLifetimeScope` and expect them to work like intended.
+
+```csharp
+builder.RegisterType<Database>().InstancePerLifetimeScope();
+```
+
 ### Deterministic Disposal
 
 The *child lifetime scope* is disposed as soon as current background job is performed, successfully or with an exception. Since *Autofac* automatically disposes all the components that implement the `IDisposable` interface (if this feature not disabled), all of the resolved components will be disposed *if appropriate*.


### PR DESCRIPTION
Added useTaggedLifetimeScope for AutofacJobActivator. If the flag is set to false during configuration of Hangfire then we don't need to use InstancePerBackgroundJob extension on services registrations so we don't block ourselves from using those in SingleInstance scopes as dependencies. 

This resolves errors of this kind:
>  "No scope with a Tag matching 'BackgroundJobScope' is visible from the scope in which the instance was requested. This generally indicates that a component registered as per-HTTP request is being requested by a SingleInstance() component (or a similar scenario.) Under the web integration always request dependencies from the DependencyResolver.Current or ILifetimeScopeProvider.RequestLifetime, never from the container itself."

Those errors happen if you use InstancePerBackgroundJob extension and you try to resolve those in a scope which doesn't see `BackgroundJobScope`.