### PR TITLE
Allow combining lifetime scope tags

### DIFF
--- a/HangFire.Autofac/RegistrationExtensions.cs
+++ b/HangFire.Autofac/RegistrationExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using Autofac;
 using Autofac.Builder;
 using Hangfire.Annotations;
 
@@ -17,16 +19,44 @@ namespace Hangfire
         /// <typeparam name="TActivatorData">Activator data type.</typeparam>
         /// <typeparam name="TStyle">Registration style.</typeparam>
         /// <param name="registration">The registration to configure.</param>
+        /// <param name="lifetimeScopeTags">Additional tags applied for matching lifetime scopes.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         /// <exception cref="ArgumentNullException">
         /// Thrown when <paramref name="registration"/> is <see langword="null"/>.
         /// </exception>
         public static IRegistrationBuilder<TLimit, TActivatorData, TStyle>
             InstancePerBackgroundJob<TLimit, TActivatorData, TStyle>(
-            [NotNull] this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration)
+            [NotNull] this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration,
+            params object[] lifetimeScopeTags)
         {
             if (registration == null) throw new ArgumentNullException("registration");
-            return registration.InstancePerMatchingLifetimeScope(AutofacJobActivator.LifetimeScopeTag);
+            
+            var tags = new[] { AutofacJobActivator.LifetimeScopeTag }.Concat(lifetimeScopeTags).ToArray();
+            return registration.InstancePerMatchingLifetimeScope(tags);
+        }
+        
+         /// <summary>
+        /// Share one instance of the component within the context of a single
+        /// processing background job instance or web request.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+        /// <typeparam name="TStyle">Registration style.</typeparam>
+        /// <param name="registration">The registration to configure.</param>
+        /// <param name="lifetimeScopeTags">Additional tags applied for matching lifetime scopes.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="registration"/> is <see langword="null"/>.
+        /// </exception>
+        public static IRegistrationBuilder<TLimit, TActivatorData, TStyle>
+            InstancePerRequestOrBackgroundJob<TLimit, TActivatorData, TStyle>(
+            [NotNull] this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration,
+            params object[] lifetimeScopeTags)
+        {
+            if (registration == null) throw new ArgumentNullException("registration");
+            
+            var tags = new[] { AutofacJobActivator.LifetimeScopeTag }.Concat(lifetimeScopeTags).ToArray();
+            return registration.InstancePerRequest(tags);
         }
     }
 }


### PR DESCRIPTION
Lets Hangfire play nicely with registrations made using `InstancePerRequest`.

`InstancePerBackgroundJob` now takes additional lifetimeScopeTags to allow matching against any of the provided lifetime scopes (this matches Autofac's own implementations of `InstancePerRequest` and `InstancePerMatchingLifetimeScope`). This lets people call `InstancePerRequest(Hangfire.AutofacJobActivator.LifetimeScopeTag)`.

I've also included `InstancePerRequestOrBackgroundJob` which automatically includes both the Autofac web request tag and the Hangfire job tag, as well as including the `lifetimeScopeTags` parameter for users to chain their own tags as needed.