### PR TITLE
Allow combining lifetime scope tags

### DIFF
--- a/HangFire.Autofac.Tests/AutofacJobActivatorTests.cs
+++ b/HangFire.Autofac.Tests/AutofacJobActivatorTests.cs
@@ -178,6 +178,34 @@ namespace Hangfire.Autofac.Tests
         }
 
         [TestMethod]
+        public void InstancePerJob_RegisteredWithExtraTags_ResolvesForJobScope()
+        {
+            var alternateLifetimeScopeTag = new object();
+            _builder.Register(c => new object()).As<object>()
+               .InstancePerBackgroundJob(alternateLifetimeScopeTag);
+            var activator = CreateActivator();
+
+            using (var scope = activator.BeginScope())
+            {
+                var instance = scope.Resolve(typeof(object));
+            }
+        }
+
+        [TestMethod]
+        public void InstancePerJob_RegisteredWithExtraTags_ResolvesForAlternateScope()
+        {
+            var alternateLifetimeScopeTag = new object();
+            _builder.Register(c => new object()).As<object>()
+               .InstancePerBackgroundJob(alternateLifetimeScopeTag);
+            var container = _builder.Build();
+
+            using (var scope = container.BeginLifetimeScope(alternateLifetimeScopeTag))
+            {
+                var instance = scope.Resolve(typeof(object));
+            }
+        }
+
+        [TestMethod]
         public void UseAutofacActivator_CallsUseActivatorCorrectly()
         {
             var configuration = new Mock<IBootstrapperConfiguration>();

--- a/HangFire.Autofac/RegistrationExtensions.cs
+++ b/HangFire.Autofac/RegistrationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Autofac.Builder;
 using Hangfire.Annotations;
 
@@ -17,16 +18,20 @@ namespace Hangfire
         /// <typeparam name="TActivatorData">Activator data type.</typeparam>
         /// <typeparam name="TStyle">Registration style.</typeparam>
         /// <param name="registration">The registration to configure.</param>
+        /// <param name="lifetimeScopeTags">Additional tags applied for matching lifetime scopes.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         /// <exception cref="ArgumentNullException">
         /// Thrown when <paramref name="registration"/> is <see langword="null"/>.
         /// </exception>
         public static IRegistrationBuilder<TLimit, TActivatorData, TStyle>
             InstancePerBackgroundJob<TLimit, TActivatorData, TStyle>(
-            [NotNull] this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration)
+            [NotNull] this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration,
+            params object[] lifetimeScopeTags)
         {
             if (registration == null) throw new ArgumentNullException("registration");
-            return registration.InstancePerMatchingLifetimeScope(AutofacJobActivator.LifetimeScopeTag);
+            
+            var tags = new[] { AutofacJobActivator.LifetimeScopeTag }.Concat(lifetimeScopeTags).ToArray();
+            return registration.InstancePerMatchingLifetimeScope(tags);
         }
     }
 }

--- a/HangFire.Autofac/RegistrationExtensions.cs
+++ b/HangFire.Autofac/RegistrationExtensions.cs
@@ -18,6 +18,25 @@ namespace Hangfire
         /// <typeparam name="TActivatorData">Activator data type.</typeparam>
         /// <typeparam name="TStyle">Registration style.</typeparam>
         /// <param name="registration">The registration to configure.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="registration"/> is <see langword="null"/>.
+        /// </exception>
+        public static IRegistrationBuilder<TLimit, TActivatorData, TStyle>
+            InstancePerBackgroundJob<TLimit, TActivatorData, TStyle>(
+            [NotNull] this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration)
+        {
+            return registration.InstancePerBackgroundJob(new object[] { });
+        }
+
+        /// <summary>
+        /// Share one instance of the component within the context of a single
+        /// processing background job instance.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+        /// <typeparam name="TStyle">Registration style.</typeparam>
+        /// <param name="registration">The registration to configure.</param>
         /// <param name="lifetimeScopeTags">Additional tags applied for matching lifetime scopes.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         /// <exception cref="ArgumentNullException">
@@ -29,7 +48,7 @@ namespace Hangfire
             params object[] lifetimeScopeTags)
         {
             if (registration == null) throw new ArgumentNullException("registration");
-            
+
             var tags = new[] { AutofacJobActivator.LifetimeScopeTag }.Concat(lifetimeScopeTags).ToArray();
             return registration.InstancePerMatchingLifetimeScope(tags);
         }


### PR DESCRIPTION
Autofac's lifetimeScope registration methods such as `InstancePerRequest` and `InstancePerMatchingLifetimeScope` take a `params object[] lifetimeScopeTags` at the end allowing easy combining of allowed scopes. I've added this parameter to `InstancePerBackgroundJob`.

This lets people call `InstancePerBackgroundJob(Autofac.Core.Lifetime.MatchingScopeLifetimeTags.RequestLifetimeScopeTag)` allowing for proper registration of a component for either webrequests or background jobs, as well as allowing people to bring in their own tags if needed.